### PR TITLE
properly parse the quaternion data from the steam controller

### DIFF
--- a/include/steam_controller/steam_controller.hpp
+++ b/include/steam_controller/steam_controller.hpp
@@ -59,6 +59,11 @@ struct vec3
     int16_t x, y, z;
 };
 
+struct quat
+{
+    int16_t x, y, z, w;
+};
+
 enum class event_key : uint32_t
 {
     UPDATE = (1),
@@ -79,7 +84,7 @@ struct update_event
     vec2 left_axis;
     vec2 right_axis;
 
-    vec3 orientation;
+    quat orientation;
     vec3 acceleration;
     vec3 angular_velocity;
 };

--- a/source/steam_controller.cpp
+++ b/source/steam_controller.cpp
@@ -338,9 +338,10 @@ uint8_t parse_event(steam_controller::event* pEvent, const uint8_t* eventData, i
         pEvent->update.angular_velocity.y = eventData[0x24] | (eventData[0x25] << 8);
         pEvent->update.angular_velocity.z = eventData[0x26] | (eventData[0x27] << 8);
 
-        pEvent->update.orientation.x = eventData[0x28] | (eventData[0x29] << 8);
-        pEvent->update.orientation.y = eventData[0x2a] | (eventData[0x2b] << 8);
-        pEvent->update.orientation.z = eventData[0x2c] | (eventData[0x2d] << 8);
+        pEvent->update.orientation.w = eventData[0x28] | (eventData[0x29] << 8);
+        pEvent->update.orientation.x = eventData[0x2a] | (eventData[0x2b] << 8);
+        pEvent->update.orientation.y = eventData[0x2c] | (eventData[0x2d] << 8);
+        pEvent->update.orientation.z = eventData[0x2e] | (eventData[0x2f] << 8);
         break;
 
     case static_cast<std::uint8_t>(event_key::BATTERY):


### PR DESCRIPTION
the SC actually outputs a quaternion, so a fourth value has to be read to handle it properly.
also the structure representing the orientation is now a four-vector

details about quaternions are rather painful but never the less interesting!
https://en.wikipedia.org/wiki/Quaternion

cheers